### PR TITLE
Fix relying on exceptions implementing Throwable interface 

### DIFF
--- a/src/DefaultLogger.php
+++ b/src/DefaultLogger.php
@@ -43,9 +43,14 @@ class DefaultLogger extends AbstractLogger
         $microTime = microtime(true);
         $micro = sprintf("%06d", ($microTime - floor($microTime)) * 1000000);
         $logTime = (new \DateTime(date('Y-m-d H:i:s.' . $micro, $microTime)))->format('Y-m-d H:i:s.u');
+        
+        $msg_line = ($exception instanceOf \Throwable)
+            ? $exception->getMessage()
+            : (is_string($exception) ? $exception : print_r($exception, (bool) "noecho"));
+
         error_log(
             '[' . $logTime . '] '
-            .$message.($exception ? ' {Exception: '.$exception->getMessage().'}' : '')."\n",
+            .$message.($exception ? ' {Exception: '.$msg_line.'}' : '')."\n",
             3,
             $this->file,
             null


### PR DESCRIPTION
Just had the case that `$exception` was a string, and PageCache not checking for `\Throwable` interface. So calling `$exception->getMessage()` caused PageCache to fail.