### PR TITLE
Upgrade PSR dependencies to v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ PageCache ChangeLog
 * Fixed PHP 8.1 deprecation: implicit float-to-int conversion in `DefaultLogger` and `CacheItemStorage`.
 * Fixed PHP 8.1 deprecation: passing `null` for typed `int` parameter in `HttpHeaders::setHeader()`.
 * Replaced Travis CI with GitHub Actions; matrix now covers PHP 8.1, 8.2, 8.3, 8.4, and 8.5.
+* `psr/log` requirement upgraded from `^1.0` to `^3.0`.
+* `psr/simple-cache` requirement upgraded from `^1.0` to `^3.0`.
 
 ### WIP
 

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": ">=8.1",
-        "psr/simple-cache": "^1.0",
-        "psr/log": "^1.0"
+        "psr/simple-cache": "^3.0",
+        "psr/log": "^3.0"
     },
     "require-dev": {
         "mobiledetect/mobiledetectlib": "^2.8",

--- a/src/DefaultLogger.php
+++ b/src/DefaultLogger.php
@@ -37,7 +37,7 @@ class DefaultLogger extends AbstractLogger
      *
      * @return void
      */
-    public function log($level, $message, array $context = [])
+    public function log($level, string|\Stringable $message, array $context = []): void
     {
         $exception = isset($context['exception']) ? $context['exception'] : null;
         $microTime = microtime(true);

--- a/src/PageCache.php
+++ b/src/PageCache.php
@@ -363,7 +363,7 @@ class PageCache
      * @throws \PageCache\PageCacheException
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
-    public function clearPageCache(CacheItemInterface $item = null)
+    public function clearPageCache(?CacheItemInterface $item = null)
     {
         // Use current item if not provided in arguments
         if (is_null($item)) {
@@ -400,7 +400,7 @@ class PageCache
      * @return bool Returns true if page has a valid cache file saved, false if not
      * @throws \Psr\SimpleCache\InvalidArgumentException
      */
-    public function isCached(CacheItemInterface $item = null)
+    public function isCached(?CacheItemInterface $item = null)
     {
         if (!$item) {
             $key = $this->getCurrentKey();

--- a/src/Storage/CacheItemStorage.php
+++ b/src/Storage/CacheItemStorage.php
@@ -103,7 +103,7 @@ class CacheItemStorage
      *
      * @return bool
      */
-    private function isExpired(CacheItemInterface $item, DateTime $time = null)
+    private function isExpired(CacheItemInterface $item, ?DateTime $time = null)
     {
         $time = $time ?: new DateTime();
         return ($time > $item->getExpiresAt());

--- a/src/Storage/FileSystem/FileSystemCacheAdapter.php
+++ b/src/Storage/FileSystem/FileSystemCacheAdapter.php
@@ -79,7 +79,7 @@ class FileSystemCacheAdapter implements CacheInterface
      *       MUST be thrown if the $key string is not a legal value.
      * @throws \PageCache\PageCacheException
      */
-    public function has($key)
+    public function has($key): bool
     {
         $path = $this->getKeyPath($key);
 
@@ -97,7 +97,7 @@ class FileSystemCacheAdapter implements CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *       MUST be thrown if the $key string is not a legal value.
      */
-    public function get($key, $default = null)
+    public function get($key, mixed $default = null): mixed
     {
         $path = $this->getKeyPath($key);
 
@@ -145,7 +145,7 @@ class FileSystemCacheAdapter implements CacheInterface
      * @throws \PageCache\Storage\CacheAdapterException
      * @throws \Exception
      */
-    public function set($key, $value, $ttl = null)
+    public function set($key, mixed $value, $ttl = null): bool
     {
         $ttl = $this->normalizeTtl($ttl);
 
@@ -186,7 +186,7 @@ class FileSystemCacheAdapter implements CacheInterface
      * @throws \Psr\SimpleCache\InvalidArgumentException
      *   MUST be thrown if the $key string is not a legal value.
      */
-    public function delete($key)
+    public function delete($key): bool
     {
         $path = $this->getKeyPath($key);
 
@@ -210,7 +210,7 @@ class FileSystemCacheAdapter implements CacheInterface
      *
      * @return bool True on success and false on failure.
      */
-    public function clear()
+    public function clear(): bool
     {
         return $this->hashDirectory->clearDirectory($this->path);
     }
@@ -227,7 +227,7 @@ class FileSystemCacheAdapter implements CacheInterface
      *   MUST be thrown if $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
-    public function getMultiple($keys, $default = null)
+    public function getMultiple($keys, mixed $default = null): iterable
     {
         if (!$keys || (!\is_array($keys) && !$keys instanceof \Traversable)) {
             throw new InvalidArgumentException('Cache keys must be an array or Traversable');
@@ -257,7 +257,7 @@ class FileSystemCacheAdapter implements CacheInterface
      *   MUST be thrown if $values is neither an array nor a Traversable,
      *   or if any of the $values are not a legal value.
      */
-    public function setMultiple($values, $ttl = null)
+    public function setMultiple($values, $ttl = null): bool
     {
         if (!$values || (!\is_array($values) && !$values instanceof \Traversable)) {
             throw new InvalidArgumentException('Cache values must be an array or Traversable');
@@ -287,7 +287,7 @@ class FileSystemCacheAdapter implements CacheInterface
      *   MUST be thrown if $keys is neither an array nor a Traversable,
      *   or if any of the $keys are not a legal value.
      */
-    public function deleteMultiple($keys)
+    public function deleteMultiple($keys): bool
     {
         if (!\is_array($keys) && !$keys instanceof \Traversable) {
             throw new InvalidArgumentException('Cache keys must be an array or Traversable');

--- a/tests/Integration/IntegrationWebServerTest.php
+++ b/tests/Integration/IntegrationWebServerTest.php
@@ -422,7 +422,7 @@ class IntegrationWebServerTest extends \PHPUnit\Framework\TestCase
      *
      * @return \GuzzleHttp\Psr7\Request
      */
-    private function makeRequest($contentFileName, array $queryParams = null)
+    private function makeRequest($contentFileName, ?array $queryParams = null)
     {
         $uri = new Uri('/'.$contentFileName);
 


### PR DESCRIPTION
## Upgrade PSR dependencies to v3

  ### Summary

  - Bumps `psr/log` from `^1.0` to `^3.0` and `psr/simple-cache` from `^1.0` to `^3.0`, aligning with modern PHP 8.1+ projects
  - Adds return types to all 8 `CacheInterface` methods in `FileSystemCacheAdapter` to satisfy PSR-16 v3's typed interface
  - Fixes PHP 8.4+ deprecation warnings for implicit nullable parameters across `PageCache`, `CacheItemStorage`, and test files
  - Updates `DefaultLogger::log()` signature to match PSR-3 v3 (`string|\Stringable $message`, `: void` return type)

  ### Why

  The previous constraints (`psr/log: ^1.0`, `psr/simple-cache: ^1.0`) would force modern projects to downgrade their PSR dependencies when installing this
  library. Since we already require PHP ≥ 8.1, upgrading to PSR v3 is the natural fit and was deferred from the initial v3.0.0 release.

  ### Notes

  - Parameter types on `CacheInterface` methods are intentionally left untyped (PHP allows widening in implementations). This preserves our own `validateKey()`
  / `normalizeTtl()` validation which throws `Psr\SimpleCache\InvalidArgumentException` as the PSR spec requires — typed parameters would cause PHP to throw
  `TypeError` instead, breaking the `cache/integration-tests` suite.
  - All 281 tests pass on PHP 8.1 – 8.5.